### PR TITLE
Fix/edit transaction modal

### DIFF
--- a/src/features/transactions/components/modals/EditTransaction.jsx
+++ b/src/features/transactions/components/modals/EditTransaction.jsx
@@ -100,7 +100,7 @@ const EditTransaction = ({ transaction, handleClose }) => {
   }, [fetchData]);
 
   const groupCategoryByType = (categories) => {
-    const groupedCategories = categories.reduce((acc, category) => {
+    const groupedCategories = (categories || []).reduce((acc, category) => {
       const type = category.type || "other";
       if (!acc[type]) {
         acc[type] = [];


### PR DESCRIPTION
Fix bug that causes flickering on click of the edit button of a transaction preventing the user from editing a specific transaction. 