### PR TITLE
Switch Invoice List to Full-View Scroll for Adjustable Pagination

### DIFF
--- a/src/Layouts/components/wrappers/ContentViewArea.jsx
+++ b/src/Layouts/components/wrappers/ContentViewArea.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const ContentViewArea = ({ children }) => {
   return (
-    <section className="p-6 md:py-16 md:px-8 flex-1 flex flex-col h-full w-full overflow-auto">
+    <section className="p-6 md:py-16 md:px-8 flex flex-col h-full w-full overflow-auto">
       {children}
     </section>
   );

--- a/src/components/common/EmptyState.jsx
+++ b/src/components/common/EmptyState.jsx
@@ -8,7 +8,7 @@ export default function EmptyState({
   onAction,
 }) {
   return (
-    <article className="flex flex-col items-center gap-y-4">
+    <article className="flex flex-1 flex-col items-center gap-y-4">
       <div className="flex justify-center items-center rounded-full bg-grey w-24 h-24">
         <Icon variation="black" />
       </div>

--- a/src/features/invoicing/pages/Invoices.jsx
+++ b/src/features/invoicing/pages/Invoices.jsx
@@ -10,7 +10,7 @@ export function InvoicesPage() {
       <section className="flex flex-col gap-y-2">
         <InvoiceHeader />
       </section>
-      <main className="flex-1 flex justify-center items-center overflow-auto">
+      <main className="flex flex-1 min-h-fit justify-center items-center">
         <Suspense fallback={<InvoicesSkeleton />}>
           <InvoiceContent />
         </Suspense>


### PR DESCRIPTION
### Summary
Implements full-view scrolling for the invoice list in the invoicing feature, replacing the fixed-height table scroll. This enhances UX for adjustable pagination (10, 25, 50 items per page).

### Changes
- Updated invoice list container to handle full-view scrolling.
- Removed auto overflow from the view container
- Ensured compatibility with pagination options.

### Related Issue
Closes #61 

### Testing
- Tested scrolling with 10, 25, 50 items per page.
- Verified on Chrome, Firefox, and mobile devices.
- Confirmed no content overflow.

### Checklist
- [x] Responsive across screen sizes.